### PR TITLE
Support partitioning into storable and unstorable parts

### DIFF
--- a/src/alandipert/storage_atom.cljs
+++ b/src/alandipert/storage_atom.cljs
@@ -60,42 +60,107 @@ discarded an only the new one is committed."
 (def ^:dynamic *watch-active* true)
 ;; To prevent a save/load loop when changing the values quickly.
 
+(defprotocol IPartitioning
+  "A set of operations that allows a value to be partitioned into two parts:
+  the *storable* part that should be stored into the storage and *unstorable*
+  part that shouldn't.  A typical target of the operations would be an
+  application database.
+
+  The operations are:
+
+  - `split` (`[partitioning value]`): Splits `value` into a vector
+    `[unstorable storable]`.
+
+  - `join` (`[partitioning [unstorable storable]]`): Joins the vector
+    `[unstorable storable]` back into a value representing the whole.
+
+  An `IPartitioning` should always satisfy the following invariant for all
+  meaningful values:
+
+  ```
+  (= (->> value
+          (split partitioning)
+          (join partitioning))
+     value)
+  ```"
+  (split [this value]
+    "Split `value` into a vector of form `[unstorable storable]`.")
+  (join [this parts]
+    "Join `parts`, a vector of form `[unstorable storable]`, into value
+    representing the whole."))
+
+(defn get-unstorable
+  "Return the unstorable part of `value` based on `partitioning`."
+  [partitioning value]
+  (->> value (split partitioning) (first)))
+
+(defn get-storable
+  "Return the storable part of `value` based on `partitioning`."
+  [partitioning value]
+  (->> value (split partitioning) (second)))
+
+(defn swap-storable
+  "Given `partitioning` replace the storable part of `value` with `storable`
+  leaving the unstorable part untouched."
+  [value partitioning storable]
+  (join partitioning [(get-unstorable partitioning value) storable]))
+
+(def store-all
+  "A partitioning that results in storing everything into the storage."
+  (reify IPartitioning
+    (split [_ value]
+      [nil value])
+    (join [_ [_ stored]]
+      stored)))
+
 (defn store
-  [atom backend]
+  [atom backend partitioning]
   (let [existing (-get backend ::none)
         debounce (debounce-factory)]
     (if (= ::none existing)
-      (-commit! backend @atom)
-      (reset! atom existing))
+      (->> @atom (get-storable partitioning) (-commit! backend))
+      (swap! atom swap-storable partitioning existing))
     (doto atom
       (add-watch ::storage-watch
-                 #(when (and *watch-active*
-                             (not= %3 %4))
-                    (debounce (fn [](-commit! backend %4))
-                              (or *storage-delay*
-                                  @storage-delay)))))))
+                 (fn [_ _ old-value new-value]
+                   (let [new-storable (get-storable partitioning new-value)]
+                     (when (and *watch-active*
+                                (not= (get-storable partitioning old-value)
+                                      new-storable))
+                       (debounce (fn []
+                                   (-commit! backend new-storable))
+                                 (or *storage-delay*
+                                     @storage-delay)))))))))
 
 (defn maybe-update-backend
-  [atom storage k default e]
+  [atom storage k partitioning initial-storable e]
   (when (identical? storage (.-storageArea e))
     (if (empty? (.-key e)) ;; is all storage is being cleared?
       (binding [*watch-active* false]
-        (reset! atom default))
+        (swap! atom swap-storable partitioning initial-storable))
       (try
         (when-let [sk (json->clj (.-key e))]
           (when (= sk k) ;; is the stored key the one we are looking for?
             (binding [*watch-active* false]
-              (reset! atom (let [value (.-newValue e)] ;; new value, or is key being removed?
-                             (if-not (string/blank? value)
-                               (json->clj value)
-                               default))))))
+              (swap! atom
+                     swap-storable
+                     partitioning
+                     (let [value (.-newValue e)] ;; new value, or is key being removed?
+                       (if-not (string/blank? value)
+                         (json->clj value)
+                         initial-storable))))))
         (catch :default e)))))
 
 (defn link-storage
-  [atom storage k]
-  (let [default @atom]
+  [atom storage k partitioning]
+  (let [[_ initial-storable] (split partitioning @atom)]
     (.addEventListener js/window "storage"
-                       #(maybe-update-backend atom storage k default %))))
+                       #(maybe-update-backend atom
+                                              storage
+                                              k
+                                              partitioning
+                                              initial-storable
+                                              %))))
 
 (defn dispatch-synthetic-event!
   "Create and dispatch a synthetic StorageEvent. Expects `key` to be a string
@@ -130,17 +195,19 @@ discarded an only the new one is committed."
 ;;; main API
 
 (defn html-storage
-  [atom storage k]
-  (link-storage atom storage k)
-  (store atom (StorageBackend. storage k)))
+  ([atom storage k]
+   (html-storage atom storage k {}))
+  ([atom storage k {:keys [partitioning] :or {partitioning store-all}}]
+   (link-storage atom storage k partitioning)
+   (store atom (StorageBackend. storage k) partitioning)))
 
 (defn local-storage
-  [atom k]
-  (html-storage atom js/localStorage k))
+  [atom & args]
+  (apply html-storage atom js/localStorage args))
 
 (defn session-storage
-  [atom k]
-  (html-storage atom js/sessionStorage k))
+  [atom & args]
+  (apply html-storage atom js/sessionStorage args))
 
 ;; Methods to safely remove items from storage or clear storage entirely.
 


### PR DESCRIPTION
Sometimes it is desirable to persist only a part of the state held by a single atom (consider, for example, the application state in a re-frame application). Towards this end:

- Add a protocol `IPartitioning` that allows specifying how the state can be decomposed into its "storable" and "unstorable" parts and then recovered back from these parts.
- Provide a trivial `store-all` partitioning that is the default and works like there was no partitioning.
- Provide a `store-map-field` (`[key]`) constructor that builds a partitioning that stores only only the part of the state that is under the `key` field.

To-do:

- [ ] Think through the corner cases
- [ ] Amend README.md correspondingly